### PR TITLE
if docker does not bind port to 0.0.0.0 you won't access it externall…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ COPY . /app
 RUN virtualenv -p python3 /env && /env/bin/pip install -r /app/requirements.txt
 
 EXPOSE 5000
-CMD ["/env/bin/python3", "/app/app.py"]
+CMD ["/env/bin/python3", "/app/app.py", "-i", "0.0.0.0", "-p", "5000"]


### PR DESCRIPTION
…y to the docker container

Perhaps earlier versions of docker this was not an issue, but now it is with the version of docker running on ubuntu 18 at least, the symptoms are the same as:
http://imaginativethinking.ca/heck-get-connection-reset-peer-containerizing-angular-4-application/

The fix is easy